### PR TITLE
Removed requirements*.txt and moved all requirements to setup.py

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -6,12 +6,12 @@ RUN apk add --update --no-cache \
 
 # Install app code
 RUN mkdir /app
-ADD ./requirements*.txt ./setup.* README.md /app/
+ADD ./setup.* README.md /app/
 ADD cloudunmap    /app/cloudunmap
 ADD tests         /app/tests
 
 # Install app deps
-RUN cd /app && pip3 install -r requirements-dev.txt
+RUN cd /app && pip3 install -e .[dev]
 
 # Run as non-root
 RUN adduser app -S -u 1000

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,0 @@
--r requirements.txt
-flake8==3.7.7
-twine==1.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-# Install requirements from setup.py
--e .

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,13 @@ setup(
   classifiers                   = [],
   python_requires               = ' >= 3',
   install_requires              = ["boto3==1.9.123", "python-json-logger==0.1.10"],
-  entry_points                  = {
+  extras_require = {
+    'dev': [
+      'flake8==3.7.7',
+      'twine==1.13.0'
+    ]
+  },
+  entry_points = {
     'console_scripts': [
         'aws-cloud-unmap=cloudunmap.cli:run',
     ]


### PR DESCRIPTION
As suggested by @esanchezm, I adopted the approach [described here](https://stackoverflow.com/questions/28509965/setuptools-development-requirements/28842733#28842733) to get rid of `requirements.txt` and specific all requirements to `setup.py`. I tested the dev env and the package, and looks working correctly 👍 