### PR TITLE
Fixed memory leak reusing the same session

### DIFF
--- a/cloudunmap/unmap.py
+++ b/cloudunmap/unmap.py
@@ -29,13 +29,12 @@ def unmapTerminatedInstancesFromService(serviceId: str, serviceRegion: str, inst
 
     # Customize the boto client config
     botoConfig = botocore.client.Config(connect_timeout=5, read_timeout=15, retries={"max_attempts": 2})
-    botoSession = boto3.Session()
 
     # Instance Cloud Map client
-    sdClient = botoSession.client("servicediscovery", config=botoConfig, region_name=serviceRegion)
+    sdClient = boto3.client("servicediscovery", config=botoConfig, region_name=serviceRegion)
 
     # Instance EC2 clients
-    ec2Clients = [botoSession.client("ec2", config=botoConfig, region_name=region) for region in instancesRegions]
+    ec2Clients = [boto3.client("ec2", config=botoConfig, region_name=region) for region in instancesRegions]
 
     # List registered instances on CloudMap
     serviceInstances = listServiceInstances(serviceId, sdClient)
@@ -50,7 +49,6 @@ def unmapTerminatedInstancesFromService(serviceId: str, serviceRegion: str, inst
 
     for ec2Client in ec2Clients:
         instances = listEC2InstancesById(serviceInstancesId, ec2Client)
-
         # Filter out terminated instances
         instances = list(filter(lambda i: i["State"]["Name"] != "shutting-down" and i["State"]["Name"] != "terminated", instances))
 

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,11 +1,11 @@
 from unittest.mock import MagicMock
 
 
-def mockBotoSession(clients):
-    sessionMock = MagicMock()
-    sessionMock.client.side_effect = lambda name, **kwargs: clients[name]
+def mockBotoClient(clients):
+    mock = MagicMock()
+    mock.side_effect = lambda name, **kwargs: clients[name]
 
-    return sessionMock
+    return mock
 
 
 def mockServiceInstance(instanceId, ipv4=None):

--- a/tests/test_unmap.py
+++ b/tests/test_unmap.py
@@ -3,7 +3,7 @@ import boto3
 from unittest.mock import patch
 from botocore.stub import Stubber
 from cloudunmap.unmap import matchServiceInstanceInRunningInstances, unmapTerminatedInstancesFromService
-from .mocks import mockBotoSession, mockServiceInstance, mockEC2Instance
+from .mocks import mockBotoClient, mockServiceInstance, mockEC2Instance
 
 
 class TestUnmap(unittest.TestCase):
@@ -17,7 +17,7 @@ class TestUnmap(unittest.TestCase):
         self.ec2Stubber = Stubber(self.ec2Client)
         self.ec2Stubber.activate()
 
-        self.sessionMock = mockBotoSession({"ec2": self.ec2Client, "servicediscovery": self.sdClient})
+        self.botoClientMock = mockBotoClient({"ec2": self.ec2Client, "servicediscovery": self.sdClient})
 
     #
     # matchServiceInstanceInRunningInstances()
@@ -67,7 +67,7 @@ class TestUnmap(unittest.TestCase):
             ]}]},
             {"Filters": [{"Name": "instance-id", "Values": ["i-1", "i-2"]}], "MaxResults": 1000})
 
-        with patch("boto3.Session", return_value=self.sessionMock):
+        with patch("boto3.client", side_effect=self.botoClientMock):
             unmapTerminatedInstancesFromService(serviceId="srv-1", serviceRegion="eu-west-1", instancesRegions=["eu-west-1"])
 
         self.ec2Stubber.assert_no_pending_responses()
@@ -92,7 +92,7 @@ class TestUnmap(unittest.TestCase):
             ]}]},
             {"Filters": [{"Name": "instance-id", "Values": ["i-1", "i-2"]}], "MaxResults": 1000})
 
-        with patch("boto3.Session", return_value=self.sessionMock):
+        with patch("boto3.client", side_effect=self.botoClientMock):
             unmapTerminatedInstancesFromService(serviceId="srv-1", serviceRegion="eu-west-1", instancesRegions=["eu-west-1"])
 
         self.ec2Stubber.assert_no_pending_responses()
@@ -118,7 +118,7 @@ class TestUnmap(unittest.TestCase):
             ]}]},
             {"Filters": [{"Name": "instance-id", "Values": ["i-1", "i-2"]}], "MaxResults": 1000})
 
-        with patch("boto3.Session", return_value=self.sessionMock):
+        with patch("boto3.client", side_effect=self.botoClientMock):
             unmapTerminatedInstancesFromService(serviceId="srv-1", serviceRegion="eu-west-1", instancesRegions=["eu-west-1"])
 
         self.ec2Stubber.assert_no_pending_responses()
@@ -144,7 +144,7 @@ class TestUnmap(unittest.TestCase):
             ]}]},
             {"Filters": [{"Name": "instance-id", "Values": ["i-1", "i-2"]}], "MaxResults": 1000})
 
-        with patch("boto3.Session", return_value=self.sessionMock):
+        with patch("boto3.client", side_effect=self.botoClientMock):
             unmapTerminatedInstancesFromService(serviceId="srv-1", serviceRegion="eu-west-1", instancesRegions=["eu-west-1"])
 
         self.ec2Stubber.assert_no_pending_responses()
@@ -170,7 +170,7 @@ class TestUnmap(unittest.TestCase):
             ]}]},
             {"Filters": [{"Name": "instance-id", "Values": ["i-1", "i-2"]}], "MaxResults": 1000})
 
-        with patch("boto3.Session", return_value=self.sessionMock):
+        with patch("boto3.client", side_effect=self.botoClientMock):
             unmapTerminatedInstancesFromService(serviceId="srv-1", serviceRegion="eu-west-1", instancesRegions=["eu-west-1"])
 
         self.ec2Stubber.assert_no_pending_responses()
@@ -191,7 +191,7 @@ class TestUnmap(unittest.TestCase):
             ]}]},
             {"Filters": [{"Name": "instance-id", "Values": ["i-1"]}], "MaxResults": 1000})
 
-        with patch("boto3.Session", return_value=self.sessionMock):
+        with patch("boto3.client", side_effect=self.botoClientMock):
             unmapTerminatedInstancesFromService(serviceId="srv-1", serviceRegion="eu-west-1", instancesRegions=["eu-west-1"])
 
         self.ec2Stubber.assert_no_pending_responses()
@@ -210,7 +210,7 @@ class TestUnmap(unittest.TestCase):
             {"Reservations": []},
             {"Filters": [{"Name": "instance-id", "Values": ["i-1", "i-2"]}], "MaxResults": 1000})
 
-        with patch("boto3.Session", return_value=self.sessionMock):
+        with patch("boto3.client", side_effect=self.botoClientMock):
             unmapTerminatedInstancesFromService(serviceId="srv-1", serviceRegion="eu-west-1", instancesRegions=["eu-west-1"])
 
         self.ec2Stubber.assert_no_pending_responses()
@@ -237,7 +237,7 @@ class TestUnmap(unittest.TestCase):
             {"Reservations": [{"Instances": [mockEC2Instance("i-2", publicIp="2.2.2.2")]}]},
             {"Filters": [{"Name": "instance-id", "Values": ["i-1", "i-2", "i-3"]}], "MaxResults": 1000})
 
-        with patch("boto3.Session", return_value=self.sessionMock):
+        with patch("boto3.client", side_effect=self.botoClientMock):
             unmapTerminatedInstancesFromService(serviceId="srv-1", serviceRegion="eu-west-1", instancesRegions=["eu-west-1", "us-east-1"])
 
         self.ec2Stubber.assert_no_pending_responses()


### PR DESCRIPTION
For each reconcile I was creating a new `boto3.Session()`, leading to memory leak. I switch clients creation directly to `boto3.client()`, so that the default session is reused every time.

I've aggressively tested it in the dev env with `--frequency 1`, and there's no memory leak anymore.