### PR TITLE
Export prometheus metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 1.1.0 (2019-04-02)
+- Introduced a built-in Prometheus exporter
+
 ### 1.0.4 (2019-03-29)
 - [BUGFIX] Fixed memory leak
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The application features an integrated Prometheus exporter. The following metric
 | Metric name                                                | Labels       | Description |
 | ---------------------------------------------------------- | ------------ | ----------- |
 | `aws_cloud_unmap_up`                                       | `service_id` | Always `1`: can be used to check if it's running |
-| `aws_cloud_unmap_last_reconcile_success_timestamp_seconds` | `service_id` | The epoch (seconds) of when a the service has been successfully reconciled the last time |
+| `aws_cloud_unmap_last_reconcile_success_timestamp_seconds` | `service_id` | The timestamp (in seconds) of the last successful reconciliation |
 
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The cli supports the following arguments:
 | `--instances-region REGION [REGION ...]` | yes      | AWS regions where EC2 instances should be checked |
 | `--frequency N`                          |          | How frequently the service should be reconciled (in seconds). Defaults to `300` sec |
 | `--single-run`                           |          | Run a single reconcile and then exit |
-| `--prometheus-enabled`                   |          | Enable the Prometheus exporter. Disabled by default |
+| `--enable-prometheus`                    |          | Enable the Prometheus exporter. Disabled by default |
 | `--prometheus-host`                      |          | The host at which the Prometheus exporter should listen to. Defaults to `127.0.0.1` |
 | `--prometheus-port`                      |          | The port at which the Prometheus exporter should listen to. Defaults to `9100` |
 | `--log-level LOG_LEVEL`                  |          | Minimum log level. Accepted values are: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. Defaults to `INFO` |

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ The cli supports the following arguments:
 
 The application features an integrated Prometheus exporter. The following metrics are exported:
 
-| Metric name                                        | Labels       | Description |
-| -------------------------------------------------- | ------------ | ----------- |
-| `aws_cloud_unmap_up`                               | `service_id` | Always `1`: can be used to check if it's running |
-| `aws_cloud_unmap_last_reconcile_timestamp_seconds` | `service_id` | The epoch (seconds) of when a the service has been successfully reconciled the last time |
+| Metric name                                                | Labels       | Description |
+| ---------------------------------------------------------- | ------------ | ----------- |
+| `aws_cloud_unmap_up`                                       | `service_id` | Always `1`: can be used to check if it's running |
+| `aws_cloud_unmap_last_reconcile_success_timestamp_seconds` | `service_id` | The epoch (seconds) of when a the service has been successfully reconciled the last time |
 
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -46,7 +46,20 @@ The cli supports the following arguments:
 | `--instances-region REGION [REGION ...]` | yes      | AWS regions where EC2 instances should be checked |
 | `--frequency N`                          |          | How frequently the service should be reconciled (in seconds). Defaults to `300` sec |
 | `--single-run`                           |          | Run a single reconcile and then exit |
+| `--prometheus-enabled`                   |          | Enable the Prometheus exporter. Disabled by default |
+| `--prometheus-host`                      |          | The host at which the Prometheus exporter should listen to. Defaults to `127.0.0.1` |
+| `--prometheus-port`                      |          | The port at which the Prometheus exporter should listen to. Defaults to `9100` |
 | `--log-level LOG_LEVEL`                  |          | Minimum log level. Accepted values are: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. Defaults to `INFO` |
+
+
+## Exported metrics
+
+The application features an integrated Prometheus exporter. The following metrics are exported:
+
+| Metric name                                        | Labels       | Description |
+| -------------------------------------------------- | ------------ | ----------- |
+| `aws_cloud_unmap_up`                               | `service_id` | Always `1`: can be used to check if it's running |
+| `aws_cloud_unmap_last_reconcile_timestamp_seconds` | `service_id` | The epoch (seconds) of when a the service has been successfully reconciled the last time |
 
 
 ## Development

--- a/cloudunmap/cli.py
+++ b/cloudunmap/cli.py
@@ -16,7 +16,7 @@ upMetric = Gauge(
     labelnames=["service_id"])
 
 lastReconcileTimestampMetric = Gauge(
-    "aws_cloud_unmap_last_reconcile_timestamp_seconds",
+    "aws_cloud_unmap_last_reconcile_success_timestamp_seconds",
     "The epoch (seconds) of when a the service has been successfully reconciled the last time",
     labelnames=["service_id"])
 

--- a/cloudunmap/cli.py
+++ b/cloudunmap/cli.py
@@ -46,7 +46,6 @@ def reconcile(serviceId: str, serviceRegion: str, instancesRegion: List[str]):
         logger.error(f"An error occurred while reconciling service {serviceId}: {str(error)}")
         success = False
 
-    # Update
     if success:
         lastReconcileTimestampMetric.labels(serviceId).set(int(time.time()))
 

--- a/cloudunmap/cli.py
+++ b/cloudunmap/cli.py
@@ -17,7 +17,7 @@ upMetric = Gauge(
 
 lastReconcileTimestampMetric = Gauge(
     "aws_cloud_unmap_last_reconcile_success_timestamp_seconds",
-    "The epoch (seconds) of when a the service has been successfully reconciled the last time",
+    "The timestamp (in seconds) of the last successful reconciliation",
     labelnames=["service_id"])
 
 

--- a/cloudunmap/cli.py
+++ b/cloudunmap/cli.py
@@ -29,7 +29,7 @@ def parseArguments(argv: List[str]):
     parser.add_argument("--instances-region", metavar="REGION", required=True, nargs='+', help="AWS region where EC2 instances should be checked")
     parser.add_argument("--frequency", metavar="N", required=False, type=int, default=300, help="How frequently the service should be reconciled (in seconds)")
     parser.add_argument("--single-run", required=False, default=False, action="store_true", help="Run a single reconcile and then exit")
-    parser.add_argument("--prometheus-enabled", required=False, default=False, action="store_true", help="Enable the Prometheus exporter")
+    parser.add_argument("--enable-prometheus", required=False, default=False, action="store_true", help="Enable the Prometheus exporter")
     parser.add_argument("--prometheus-host", required=False, default="127.0.0.1", help="The host at which the Prometheus exporter should listen to")
     parser.add_argument("--prometheus-port", required=False, default="9100", type=int, help="The port at which the Prometheus exporter should listen to")
     parser.add_argument("--log-level", help="Minimum log level. Accepted values are: DEBUG, INFO, WARNING, ERROR, CRITICAL", default="INFO")
@@ -73,7 +73,7 @@ def main(args):
     signal.signal(signal.SIGTERM, _on_sigterm)
 
     # Start Prometheus exporter
-    if args.prometheus_enabled:
+    if args.enable_prometheus:
         start_http_server(args.prometheus_port, args.prometheus_host)
         logger.info("Prometheus exporter listening on {host}:{port}".format(port=args.prometheus_port, host=args.prometheus_host))
 

--- a/cloudunmap/unmap.py
+++ b/cloudunmap/unmap.py
@@ -23,7 +23,7 @@ def matchServiceInstanceInRunningInstances(serviceInstance, runningInstances):
     return False
 
 
-def unmapTerminatedInstancesFromService(serviceId: str, serviceRegion: str, instancesRegions: List[str]):
+def unmapTerminatedInstancesFromService(serviceId: str, serviceRegion: str, instancesRegions: List[str]) -> bool:
     logger = logging.getLogger()
     logger.info(f"Checking EC2 instances registered to service {serviceId} in {serviceRegion}")
 
@@ -63,7 +63,7 @@ def unmapTerminatedInstancesFromService(serviceId: str, serviceRegion: str, inst
     # from the service
     if len(unmatchingInstances) >= len(serviceInstances):
         logger.warning(f"All instances registered to service {serviceId} appear to not match any running EC2 instance in {instancesRegions}, but skipping deregistering as safe protection")
-        return
+        return False
 
     # Remove all unmatching instances from the service
     logger.info(f"Found {len(unmatchingInstances)} instances in service {serviceId} not matching any running EC2 instance in {instancesRegions}")
@@ -73,3 +73,4 @@ def unmapTerminatedInstancesFromService(serviceId: str, serviceRegion: str, inst
         sdClient.deregister_instance(ServiceId=serviceId, InstanceId=unmatchingInstance["Id"])
 
     logger.info(f"Checked EC2 instances registered to service {serviceId} in {serviceRegion}")
+    return True

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
   keywords                      = ['aws', 'cloud map'],
   classifiers                   = [],
   python_requires               = ' >= 3',
-  install_requires              = ["boto3==1.9.123", "python-json-logger==0.1.10"],
+  install_requires              = ["boto3==1.9.123", "python-json-logger==0.1.10", "prometheus_client==0.6.0"],
   extras_require = {
     'dev': [
       'flake8==3.7.7',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,7 +49,7 @@ class TestCli(unittest.TestCase):
 
         # Check exported metrics
         self.assertEqual(prometheusDefaultRegistry.get_sample_value("aws_cloud_unmap_up", labels={"service_id": "srv-1"}), 1)
-        self.assertAlmostEqual(prometheusDefaultRegistry.get_sample_value("aws_cloud_unmap_last_reconcile_timestamp_seconds", labels={"service_id": "srv-1"}), time.time(), delta=2)
+        self.assertAlmostEqual(prometheusDefaultRegistry.get_sample_value("aws_cloud_unmap_last_reconcile_success_timestamp_seconds", labels={"service_id": "srv-1"}), time.time(), delta=2)
 
         self.ec2Stubber.assert_no_pending_responses()
         self.sdStubber.assert_no_pending_responses()
@@ -63,7 +63,7 @@ class TestCli(unittest.TestCase):
 
         # Check exported metrics
         self.assertEqual(prometheusDefaultRegistry.get_sample_value("aws_cloud_unmap_up", labels={"service_id": "srv-1"}), 1)
-        self.assertIsNone(prometheusDefaultRegistry.get_sample_value("aws_cloud_unmap_last_reconcile_timestamp_seconds", labels={"service_id": "srv-1"}))
+        self.assertIsNone(prometheusDefaultRegistry.get_sample_value("aws_cloud_unmap_last_reconcile_success_timestamp_seconds", labels={"service_id": "srv-1"}))
 
         self.ec2Stubber.assert_no_pending_responses()
         self.sdStubber.assert_no_pending_responses()
@@ -86,7 +86,7 @@ class TestCli(unittest.TestCase):
 
         # Check exported metrics
         self.assertEqual(prometheusDefaultRegistry.get_sample_value("aws_cloud_unmap_up", labels={"service_id": "srv-1"}), 1)
-        self.assertIsNone(prometheusDefaultRegistry.get_sample_value("aws_cloud_unmap_last_reconcile_timestamp_seconds", labels={"service_id": "srv-1"}))
+        self.assertIsNone(prometheusDefaultRegistry.get_sample_value("aws_cloud_unmap_last_reconcile_success_timestamp_seconds", labels={"service_id": "srv-1"}))
 
         self.ec2Stubber.assert_no_pending_responses()
         self.sdStubber.assert_no_pending_responses()


### PR DESCRIPTION
In this PR I've introduced a built-in Prometheus exporter and two exported metrics, that will help us in alerting:
- `aws_cloud_unmap_up`: alert if the app is not running
- `aws_cloud_unmap_last_reconcile_success_timestamp_seconds`: alert if the app is running, but the reconciling is failing (for any reason)

A note about tests: Prometheus client for Python does allow to `start_http_server`, but **not** to stop the HTTP server. So in tests I'm **not** enabling it via `--prometheus-enabled` because the second execution of `main()` will fail to bind the Prometheus exporter port (already binded by the first execution of `main()`), but I'm always setting the internal Prometheus metrics if when Prometheus is not enabled, so that I can assert on them. All in all, the `--prometheus-enabled` flag just turn on the HTTP server of the built-in exporter.