### PR TITLE
Return true if there are no registered instances in the service

### DIFF
--- a/cloudunmap/unmap.py
+++ b/cloudunmap/unmap.py
@@ -39,6 +39,11 @@ def unmapTerminatedInstancesFromService(serviceId: str, serviceRegion: str, inst
     # List registered instances on CloudMap
     serviceInstances = listServiceInstances(serviceId, sdClient)
 
+    # Skip in case there are no registered instances
+    if not serviceInstances:
+        logger.info(f"No registered instances in the service {serviceId}. Skipping")
+        return True
+
     # Filter out service instances without the AWS_INSTANCE_IPV4 attribute
     # and extract instance ids
     serviceInstances = list(filter(lambda i: "AWS_INSTANCE_IPV4" in i["Attributes"], serviceInstances))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,3 +90,20 @@ class TestCli(unittest.TestCase):
 
         self.ec2Stubber.assert_no_pending_responses()
         self.sdStubber.assert_no_pending_responses()
+
+    def testMainShouldDoNotDeregisterInstancesIfThereAreNoRegisteredInstances(self):
+        # Mock Cloud Map client
+        self.sdStubber.add_response(
+            "list_instances",
+            {"Instances": []},
+            {"ServiceId": "srv-1", "MaxResults": 100})
+
+        with patch("boto3.client", side_effect=self.botoClientMock):
+            main(parseArguments(["--service-id", "srv-1", "--service-region", "eu-west-1", "--instances-region", "eu-west-1", "--single-run"]))
+
+        # Check exported metrics
+        self.assertEqual(prometheusDefaultRegistry.get_sample_value("aws_cloud_unmap_up", labels={"service_id": "srv-1"}), 1)
+        self.assertIsNotNone(prometheusDefaultRegistry.get_sample_value("aws_cloud_unmap_last_reconcile_success_timestamp_seconds", labels={"service_id": "srv-1"}))
+
+        self.ec2Stubber.assert_no_pending_responses()
+        self.sdStubber.assert_no_pending_responses()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,7 +24,7 @@ class TestCli(unittest.TestCase):
         try:
             lastReconcileTimestampMetric.remove("srv-1")
             upMetric.remove("srv-1")
-        except KeyError as e:
+        except KeyError:
             pass
     #
     # main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,7 +108,7 @@ class TestCli(unittest.TestCase):
 
         # Check exported metrics
         self.assertEqual(prometheusDefaultRegistry.get_sample_value("aws_cloud_unmap_up", labels={"service_id": "srv-1"}), 1)
-        self.assertIsNotNone(prometheusDefaultRegistry.get_sample_value("aws_cloud_unmap_last_reconcile_success_timestamp_seconds", labels={"service_id": "srv-1"}))
+        self.assertAlmostEqual(prometheusDefaultRegistry.get_sample_value("aws_cloud_unmap_last_reconcile_success_timestamp_seconds", labels={"service_id": "srv-1"}), time.time(), delta=2)
 
         self.ec2Stubber.assert_no_pending_responses()
         self.sdStubber.assert_no_pending_responses()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@ import boto3
 import time
 from unittest.mock import patch
 from botocore.stub import Stubber
-from cloudunmap.cli import main, parseArguments
+from cloudunmap.cli import main, parseArguments, upMetric, lastReconcileTimestampMetric
 from .mocks import mockBotoClient, mockServiceInstance, mockEC2Instance
 from prometheus_client.registry import REGISTRY as prometheusDefaultRegistry
 
@@ -21,6 +21,11 @@ class TestCli(unittest.TestCase):
 
         self.botoClientMock = mockBotoClient({"ec2": self.ec2Client, "servicediscovery": self.sdClient})
 
+        try:
+            lastReconcileTimestampMetric.remove("srv-1")
+            upMetric.remove("srv-1")
+        except KeyError as e:
+            pass
     #
     # main()
     #


### PR DESCRIPTION
I think in this special case we should return `True` if there are no registered instances in the service. I think that makes sense considering the nature of this tool is cleanup but it's not an error to clean something empty.